### PR TITLE
add dynamic supervisors

### DIFF
--- a/lib/kv/bucket.ex
+++ b/lib/kv/bucket.ex
@@ -1,5 +1,5 @@
 defmodule KV.Bucket do
-  use Agent
+  use Agent, restart: :temporary
 
   @doc """
   Starts a new bucket

--- a/lib/kv/registry.ex
+++ b/lib/kv/registry.ex
@@ -75,10 +75,10 @@ defmodule KV.Registry do
     if Map.has_key?(names, name) do
       {:noreply, {names, refs}}
     else
-      {:ok, bucket} = KV.Bucket.start_link([])
-      ref = Process.monitor(bucket)
+      {:ok, pid} = DynamicSupervisor.start_child(KV.BucketSupervisor, KV.Bucket)
+      ref = Process.monitor(pid)
       refs = Map.put(refs, ref, name)
-      names = Map.put(names, name, bucket)
+      names = Map.put(names, name, pid)
       {:noreply, {names, refs}}
     end
   end

--- a/lib/kv/supervisor.ex
+++ b/lib/kv/supervisor.ex
@@ -15,9 +15,15 @@ defmodule KV.Supervisor do
   @impl true
   def init(:ok) do
     children = [
+      # add a dynamic supervisor as a child
+      # NB: we end up with a supervision tree when we begin supervisors
+      # that supervise other supervisors
+      {DynamicSupervisor, name: KV.BucketSupervisor, strategy: :one_for_one},
       {KV.Registry, name: KV.Registry}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    # :one_for_all strategy - the supervisor will kill and restart all of its
+    # children processes whenever any one of them dies
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/test/kv/bucket_test.exs
+++ b/test/kv/bucket_test.exs
@@ -20,4 +20,8 @@ defmodule KV.BucketTest do
     KV.Bucket.delete(bucket, "headphones")
     assert KV.Bucket.get(bucket, "headphones") == nil
   end
+
+  test "are temporary workers" do
+    assert Supervisor.child_spec(KV.Bucket, []).restart == :temporary
+  end
 end

--- a/test/kv/registry_test.exs
+++ b/test/kv/registry_test.exs
@@ -29,4 +29,13 @@ defmodule KV.RegistryTest do
     Agent.stop(bucket)
     assert KV.Registry.lookup(registry, "shopping") == :error
   end
+
+  test "removes bucket on crash", %{registry: registry} do
+    KV.Registry.create(registry, "shopping")
+    {:ok, bucket} = KV.Registry.lookup(registry, "shopping")
+
+    # Stop the bucket with non-normal reason
+    Agent.stop(bucket, :shutdown)
+    assert KV.Registry.lookup(registry, "shopping") == :error
+  end
 end


### PR DESCRIPTION
* ensure buckets are temporary
* use dynamic supervisor to start the bucket supervisor resulting in a supervision tree
* use one_for_all strategy to manage supervisor children
* add test for buckets removed on crash